### PR TITLE
Update hero branding and add donation pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,45 +91,10 @@
       top: 0;
       z-index: 1000;
       display: flex;
-      align-items: flex-start;
-      justify-content: flex-start;
-      gap: clamp(14px, 3vw, 24px);
+      align-items: center;
+      justify-content: flex-end;
       padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
       margin-bottom: 0;
-    }
-
-    .brand {
-      display: flex;
-      align-items: stretch;
-      justify-content: flex-start;
-      flex: 1;
-      flex-wrap: nowrap;
-      gap: clamp(12px, 2.6vw, 22px);
-      min-width: 0;
-    }
-
-    .brand img {
-      display: block;
-      height: auto;
-      min-height: 58px;
-    }
-
-    .brand .logo {
-      width: clamp(128px, 22vw, 204px);
-      max-width: 100%;
-      flex-shrink: 0;
-    }
-
-    .brand .wordmark {
-      flex: 1 1 auto;
-      width: 100%;
-      max-width: none;
-      min-width: 160px;
-      min-height: 58px;
-      height: auto;
-      object-fit: contain;
-      aspect-ratio: 520 / 69;
-      display: block;
     }
 
 
@@ -201,8 +166,6 @@
 
     @media (max-width: 640px) {
       header {
-        align-items: flex-start;
-        gap: 10px;
         background: transparent !important;
         padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px);
       }
@@ -216,19 +179,6 @@
       }
       .menu-btn .label {
         display: none;
-      }
-      .brand {
-        flex-direction: column;
-        gap: clamp(8px, 4vw, 16px);
-      }
-      .brand .logo {
-        width: clamp(120px, 42vw, 180px);
-      }
-      .brand .wordmark {
-        width: 100%;
-        min-width: 0;
-        max-width: none;
-        min-height: 54px;
       }
     }
 
@@ -291,9 +241,18 @@
     .hero-card {
       display: grid;
       gap: clamp(20px, 3vw, 30px);
+      position: relative;
     }
 
-    .card.disclaimer-pill {
+    .hero-card .hero-wordmark {
+      justify-self: center;
+      align-self: start;
+      width: min(320px, 60%);
+      max-width: 100%;
+      height: auto;
+    }
+
+    .card.pill-card {
       border-radius: 999px;
       padding: clamp(14px, 3vw, 22px) clamp(32px, 6vw, 44px);
       background: rgba(255, 255, 255, 0.96);
@@ -310,7 +269,8 @@
       overflow: hidden;
     }
 
-    .disclaimer-pill h2 {
+    .pill-card h2,
+    .pill-card .pill-title {
       margin: 0;
       font-size: clamp(1rem, 2.4vw, 1.25rem);
       font-weight: 900;
@@ -320,18 +280,40 @@
       white-space: nowrap;
     }
 
-    .disclaimer-pill .disclaimer-content {
+    .pill-card .pill-content {
       display: grid;
       gap: 14px;
       text-align: left;
       width: 100%;
     }
 
-    .disclaimer-pill p {
+    .pill-card p {
       margin: 0;
       font-size: 0.98rem;
       line-height: 1.55;
       color: var(--teal-600);
+    }
+
+    .pill-card.is-expanded {
+      border-radius: var(--card-radius);
+      box-shadow: 0 10px 0 rgba(15, 44, 42, 0.42);
+      flex-direction: column;
+      align-items: stretch;
+      text-align: left;
+      width: min(860px, 100%);
+      padding: clamp(24px, 4vw, 36px);
+      gap: 18px;
+    }
+
+    .disclaimer-pill {
+      background: rgba(255, 255, 255, 0.96);
+    }
+
+    .disclaimer-pill .disclaimer-content {
+      display: grid;
+      gap: 14px;
+      text-align: left;
+      width: 100%;
     }
 
     .disclaimer-pill .disclaimer-updated {
@@ -343,16 +325,8 @@
     }
 
     .disclaimer-pill.is-expanded {
-      border-radius: var(--card-radius);
       background: linear-gradient(140deg, rgba(15, 44, 42, 0.92), rgba(18, 70, 67, 0.96));
       color: var(--white);
-      box-shadow: 0 10px 0 rgba(15, 44, 42, 0.42);
-      flex-direction: column;
-      align-items: stretch;
-      text-align: left;
-      width: min(860px, 100%);
-      padding: clamp(24px, 4vw, 36px);
-      gap: 18px;
     }
 
     .disclaimer-pill.is-expanded h2 {
@@ -372,6 +346,117 @@
     .disclaimer-pill .disclaimer-seek-care {
       font-weight: 700;
       letter-spacing: 0.04em;
+    }
+
+    .donate-pill {
+      margin-top: clamp(20px, 6vw, 36px);
+      width: min(640px, 100%);
+    }
+
+    .donate-pill .pill-toggle {
+      appearance: none;
+      border: none;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      width: 100%;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .donate-pill .pill-toggle:focus-visible {
+      outline: 3px solid var(--ink-900);
+      outline-offset: 6px;
+    }
+
+    .donate-pill .pill-subtitle {
+      font-size: clamp(0.85rem, 2vw, 1rem);
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-700);
+    }
+
+    .donate-pill .pill-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      border-radius: 999px;
+      border: 2px solid currentColor;
+      font-weight: 900;
+      font-size: 1rem;
+      transition: transform 0.3s ease;
+    }
+
+    .donate-pill .donate-content {
+      display: grid;
+      gap: 16px;
+    }
+
+    .donate-pill .donate-links {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 12px;
+    }
+
+    .donate-pill .donate-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 18px;
+      border-radius: 16px;
+      border: 2px solid rgba(255, 255, 255, 0.65);
+      background: rgba(255, 255, 255, 0.15);
+      color: #ffffff;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .donate-pill .donate-links a:hover,
+    .donate-pill .donate-links a:focus-visible {
+      background: rgba(255, 255, 255, 0.3);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    .donate-pill.is-expanded {
+      background: linear-gradient(145deg, rgba(36, 166, 135, 0.94), rgba(18, 70, 67, 0.96));
+      color: #ffffff;
+      width: min(720px, 100%);
+    }
+
+    .donate-pill.is-expanded .pill-toggle {
+      align-items: flex-start;
+      text-align: left;
+    }
+
+    .donate-pill.is-expanded .pill-toggle:focus-visible {
+      outline-color: rgba(255, 255, 255, 0.85);
+    }
+
+    .donate-pill.is-expanded .pill-subtitle {
+      color: rgba(255, 255, 255, 0.86);
+    }
+
+    .donate-pill.is-expanded .pill-icon {
+      transform: rotate(45deg);
+    }
+
+    .donate-pill.is-expanded p {
+      color: rgba(255, 255, 255, 0.94);
     }
 
     .hero-card h1 {
@@ -471,11 +556,6 @@
       display: grid;
       gap: 8px;
       justify-items: center;
-    }
-
-    .calculator-header img {
-      width: clamp(86px, 12vw, 120px);
-      height: auto;
     }
 
     .calculator-header .brand-name {
@@ -909,10 +989,6 @@
   <a class="skip-link" href="#calculator">Skip to calculator</a>
   <div class="wrap">
     <header>
-      <div class="brand">
-        <img src="images/logo-hex2tone.png" class="logo" alt="CloseDose logo" />
-        <img src="images/name.png" class="wordmark" alt="CloseDose wordmark" />
-      </div>
       <button class="menu-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="siteMenu" aria-label="Open menu">
         <span class="label">Menu</span>
         <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
@@ -922,6 +998,7 @@
     <main>
       <div class="layout">
         <section class="card hero-card">
+          <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="hero-wordmark" />
           <h1>Pediatric dosing made simple</h1>
           <p>
             CloseDose helps caregivers calculate safe acetaminophen and ibuprofen doses for infants and children. Select an age range,
@@ -955,7 +1032,6 @@
 
         <section class="card card--calculator" aria-labelledby="calculator-title">
           <div class="calculator-header">
-            <img src="images/logo-hex2tone.png" alt="CloseDose badge" />
             <div class="brand-name" id="calculator-title">Dose Calculator</div>
           </div>
           <form id="calculator" novalidate>
@@ -1003,7 +1079,7 @@
           </form>
         </section>
       </div>
-      <section class="card disclaimer-pill" aria-labelledby="disclaimer-heading" aria-expanded="false">
+      <section class="card pill-card disclaimer-pill" aria-labelledby="disclaimer-heading" aria-expanded="false">
         <h2 id="disclaimer-heading">Disclaimer</h2>
         <div class="disclaimer-content" hidden>
           <p>
@@ -1018,6 +1094,36 @@
           </p>
           <p class="disclaimer-seek-care"><strong>When to seek care:</strong> ***</p>
           <p class="disclaimer-updated">Updated 9.22.2025 • Nickolas Mancini, MD, MBA</p>
+        </div>
+      </section>
+      <section class="card pill-card donate-pill" aria-labelledby="donate-heading" aria-expanded="false">
+        <button type="button" class="pill-toggle" aria-expanded="false" aria-controls="donate-content">
+          <span role="heading" aria-level="2" class="pill-title" id="donate-heading">Donate!</span>
+          <span class="pill-subtitle">Help keep CloseDose free for families.</span>
+          <span class="pill-icon" aria-hidden="true">+</span>
+        </button>
+        <div class="donate-content" id="donate-content" hidden>
+          <p>
+            CloseDose remains a free resource thanks to support from our community. If you are able, please consider donating
+            through one of the options below—every contribution helps us maintain and expand trusted pediatric dosing tools.
+          </p>
+          <ul class="donate-links">
+            <li>
+              <a href="https://www.paypal.com/donate?business=donate%40closedose.com&currency_code=USD" target="_blank" rel="noopener">
+                Donate with PayPal
+              </a>
+            </li>
+            <li>
+              <a href="https://www.buymeacoffee.com/closedose" target="_blank" rel="noopener">
+                Buy Us a Coffee
+              </a>
+            </li>
+            <li>
+              <a href="mailto:hello@closedose.com?subject=CloseDose%20Support" rel="noopener">
+                Connect for Sponsorships
+              </a>
+            </li>
+          </ul>
         </div>
       </section>
     </main>
@@ -1185,6 +1291,9 @@
       const disclaimerPill = document.querySelector('.disclaimer-pill');
       const disclaimerContent = disclaimerPill ? disclaimerPill.querySelector('.disclaimer-content') : null;
       const rootElement = document.documentElement;
+      const donatePill = document.querySelector('.donate-pill');
+      const donateToggle = donatePill ? donatePill.querySelector('.pill-toggle') : null;
+      const donateContent = donatePill ? donatePill.querySelector('.donate-content') : null;
 
       const setDisclaimerState = (expanded) => {
         if (!disclaimerPill) {
@@ -1195,6 +1304,16 @@
         if (disclaimerContent) {
           disclaimerContent.hidden = !expanded;
         }
+      };
+
+      const setDonateState = (expanded) => {
+        if (!donatePill || !donateToggle || !donateContent) {
+          return;
+        }
+        donatePill.classList.toggle('is-expanded', expanded);
+        donatePill.setAttribute('aria-expanded', String(expanded));
+        donateToggle.setAttribute('aria-expanded', String(expanded));
+        donateContent.hidden = !expanded;
       };
 
       const updateDisclaimerState = () => {
@@ -1208,6 +1327,14 @@
       updateDisclaimerState();
       window.addEventListener('scroll', updateDisclaimerState, { passive: true });
       window.addEventListener('resize', updateDisclaimerState);
+
+      if (donateToggle && donateContent) {
+        setDonateState(false);
+        donateToggle.addEventListener('click', () => {
+          const isExpanded = donatePill.classList.contains('is-expanded');
+          setDonateState(!isExpanded);
+        });
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- remove the header logo treatment and anchor the extended CloseDose wordmark to the hero card
- drop the calculator badge graphic and refresh pill-card styling to support multiple expandable sections
- add a new Donate! pill-to-card element with community support links and toggle scripting

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d585966a0c8329b9e5967a9574c8b0