### PR TITLE
Add donations page with support options

### DIFF
--- a/about.html
+++ b/about.html
@@ -531,6 +531,7 @@
         <a href="index.html">Calculator</a>
         <a href="medication-guides.html">Medication Guides</a>
         <a href="about.html" aria-current="page">About</a>
+        <a href="donations.html">Support CloseDose</a>
         <a href="contact.html">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>

--- a/contact.html
+++ b/contact.html
@@ -618,6 +618,7 @@
         <a href="index.html">Calculator</a>
         <a href="medication-guides.html">Medication Guides</a>
         <a href="about.html">About</a>
+        <a href="donations.html">Support CloseDose</a>
         <a href="contact.html" aria-current="page">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>

--- a/donations.html
+++ b/donations.html
@@ -1,0 +1,679 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light" />
+  <title>CloseDose – Support our work</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Support CloseDose" />
+  <meta
+    property="og:description"
+    content="Chip in through Buy Me a Coffee, GoFundMe, Givebutter, or PayPal to help CloseDose stay free for families."
+  />
+  <meta property="og:image" content="images/og-2400.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Support CloseDose" />
+  <meta
+    name="twitter:description"
+    content="Your donation keeps our pediatric dosing resources accurate, safe, and free for caregivers."
+  />
+  <meta name="twitter:image" content="images/og-2400.png" />
+
+  <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="images/favicon-192.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/logo-teal.png" media="(prefers-color-scheme: light)">
+  <link rel="apple-touch-icon" sizes="180x180" href="images/logo-dark.png" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#24a687" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0f2c2a" media="(prefers-color-scheme: dark)">
+
+  <style>
+    :root {
+      --teal-300: #3ec0ab;
+      --teal-400: #24a687;
+      --teal-500: #1f8f7b;
+      --teal-600: #123a37;
+      --ink-900: #0f2c2a;
+      --ink-700: #124643;
+      --bg: #f5f9f9;
+      --bg-accent: rgba(36, 166, 135, 0.14);
+      --white: #ffffff;
+      --card-bg: rgba(255, 255, 255, 0.95);
+      --card-border: 3px solid rgba(18, 58, 55, 0.16);
+      --card-radius: 26px;
+      --shadow-card: 0 14px 42px rgba(18, 58, 55, 0.15);
+      --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.2);
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Nunito", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg) url("images/light-bg.png") repeat;
+      background-size: 520px auto;
+      color: var(--ink-900);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .skip-link {
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    .skip-link:focus {
+      position: fixed;
+      left: 16px;
+      top: 16px;
+      z-index: 200;
+      width: auto;
+      height: auto;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: var(--white);
+      border: 3px solid var(--ink-900);
+      box-shadow: var(--shadow-card);
+    }
+
+    .wrap {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      position: relative;
+      top: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(12px, 3vw, 32px);
+      padding: clamp(14px, 3vw, 26px) clamp(18px, 5vw, 48px) clamp(6px, 2vw, 14px);
+      margin-bottom: 0;
+    }
+
+    .header-wordmark {
+      display: block;
+      width: min(640px, 60vw);
+      max-width: 100%;
+      height: auto;
+    }
+
+    .menu-btn {
+      appearance: none;
+      border: var(--card-border);
+      border-radius: 50%;
+      background: var(--white);
+      color: var(--ink-900);
+      font-weight: 900;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 12px;
+      font-size: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      cursor: pointer;
+      box-shadow: var(--shadow-btn);
+      transition:
+        transform 0.12s ease,
+        box-shadow 0.12s ease,
+        background 0.12s ease,
+        width 0.18s ease,
+        padding 0.18s ease,
+        border-radius 0.18s ease;
+      position: fixed;
+      top: clamp(16px, 3vw, 32px);
+      right: clamp(18px, 5vw, 48px);
+      z-index: 1200;
+      width: 64px;
+      height: 64px;
+    }
+
+    .menu-btn:focus-visible {
+      outline: 3px solid var(--teal-400);
+      outline-offset: 4px;
+    }
+
+    .menu-btn .label {
+      display: none;
+    }
+
+    .menu-btn .hamburger {
+      width: 24px;
+      height: 16px;
+      position: relative;
+    }
+
+    .menu-btn .hamburger span {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-radius: 999px;
+      background: var(--ink-900);
+      transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .menu-btn .hamburger span:nth-child(1) {
+      top: 0;
+    }
+
+    .menu-btn .hamburger span:nth-child(2) {
+      top: calc(50% - 1.5px);
+    }
+
+    .menu-btn .hamburger span:nth-child(3) {
+      bottom: 0;
+    }
+
+    main {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      padding: clamp(24px, 5vw, 60px) clamp(18px, 5vw, 48px) clamp(64px, 12vw, 120px);
+    }
+
+    .donations-page {
+      width: min(1160px, 100%);
+      display: grid;
+      gap: clamp(24px, 4vw, 36px);
+    }
+
+    .intro-card {
+      background: var(--card-bg);
+      border: var(--card-border);
+      border-radius: var(--card-radius);
+      box-shadow: var(--shadow-card);
+      padding: clamp(26px, 4vw, 42px);
+      display: grid;
+      gap: clamp(16px, 2vw, 22px);
+    }
+
+    .intro-card h1 {
+      font-size: clamp(2rem, 3vw + 1rem, 2.8rem);
+      margin: 0;
+      line-height: 1.1;
+    }
+
+    .intro-card p {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--ink-700);
+    }
+
+    .donation-grid {
+      display: grid;
+      gap: clamp(18px, 2.4vw, 28px);
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .donation-card {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      align-items: center;
+      text-align: center;
+      padding: clamp(22px, 3vw, 32px);
+      border-radius: 24px;
+      text-decoration: none;
+      color: inherit;
+      background: linear-gradient(160deg, var(--card-bg), rgba(255, 255, 255, 0.86));
+      border: 2px solid rgba(18, 58, 55, 0.12);
+      box-shadow: 0 16px 34px rgba(18, 58, 55, 0.12);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    }
+
+    .donation-card:hover,
+    .donation-card:focus-visible {
+      transform: translateY(-4px);
+      border-color: rgba(36, 166, 135, 0.42);
+      box-shadow: 0 22px 42px rgba(18, 58, 55, 0.18);
+      outline: none;
+    }
+
+    .donation-card:focus-visible {
+      box-shadow: 0 0 0 4px rgba(36, 166, 135, 0.25), 0 22px 42px rgba(18, 58, 55, 0.18);
+    }
+
+    .donation-card span {
+      font-size: 1.05rem;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+
+    .donation-card small {
+      font-size: 0.95rem;
+      color: var(--ink-700);
+    }
+
+    .donation-logo {
+      width: clamp(86px, 8vw, 112px);
+      height: clamp(86px, 8vw, 112px);
+      border-radius: 26px;
+      display: grid;
+      place-items: center;
+      background: var(--bg-accent);
+    }
+
+    .donation-logo svg {
+      width: 70%;
+      height: 70%;
+    }
+
+    .donation-logo svg .outline {
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .impact-card {
+      background: rgba(255, 255, 255, 0.88);
+      border-radius: 24px;
+      border: 2px solid rgba(18, 58, 55, 0.14);
+      padding: clamp(24px, 4vw, 36px);
+      box-shadow: 0 18px 38px rgba(18, 58, 55, 0.12);
+      display: grid;
+      gap: 16px;
+    }
+
+    .impact-card h2 {
+      margin: 0;
+      font-size: 1.6rem;
+    }
+
+    .impact-card ul {
+      margin: 0;
+      padding-left: 20px;
+      font-size: 1rem;
+      color: var(--ink-700);
+      display: grid;
+      gap: 10px;
+    }
+
+    .menu-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 1400;
+      background: rgba(12, 31, 38, 0.52);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 32px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease;
+    }
+
+    .menu-overlay.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .menu-panel {
+      background: var(--card-bg);
+      border-radius: 28px;
+      border: var(--card-border);
+      padding: clamp(24px, 4vw, 36px);
+      box-shadow: var(--shadow-card);
+      width: min(420px, 100%);
+      display: grid;
+      gap: 24px;
+    }
+
+    .menu-links {
+      display: grid;
+      gap: 12px;
+    }
+
+    .menu-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 14px 20px;
+      border-radius: 999px;
+      border: 2px solid rgba(18, 58, 55, 0.2);
+      font-weight: 700;
+      text-decoration: none;
+      color: var(--ink-900);
+      transition: background 0.18s ease, transform 0.18s ease, color 0.18s ease;
+    }
+
+    .menu-links a:hover,
+    .menu-links a:focus-visible {
+      background: rgba(36, 166, 135, 0.18);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    .menu-links a[aria-current="page"] {
+      background: rgba(36, 166, 135, 0.18);
+      border-color: rgba(36, 166, 135, 0.4);
+    }
+
+    .close-menu {
+      appearance: none;
+      border: 2px solid rgba(18, 58, 55, 0.2);
+      border-radius: 999px;
+      background: rgba(18, 58, 55, 0.12);
+      padding: 10px 18px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .close-menu:hover,
+    .close-menu:focus-visible {
+      background: rgba(18, 58, 55, 0.2);
+      outline: none;
+    }
+
+    @media (max-width: 1024px) {
+      .menu-btn {
+        position: fixed;
+        bottom: clamp(18px, 6vw, 36px);
+        top: auto;
+      }
+    }
+
+    @media (max-width: 640px) {
+      main {
+        padding: 24px clamp(14px, 6vw, 24px) 80px;
+      }
+
+      .menu-btn {
+        width: 56px;
+        height: 56px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#support-options">Skip to donation options</a>
+  <div class="wrap">
+    <header>
+      <img src="images/CloseDose_ExtendedLogo.svg" alt="CloseDose" class="header-wordmark" />
+      <button
+        class="menu-btn"
+        type="button"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="siteMenu"
+        aria-label="Open menu"
+      >
+        <span class="label">Menu</span>
+        <span class="hamburger" aria-hidden="true"><span></span><span></span><span></span></span>
+      </button>
+    </header>
+
+    <main>
+      <div class="donations-page">
+        <section class="intro-card" aria-labelledby="support-heading">
+          <h1 id="support-heading">Support CloseDose</h1>
+          <p>
+            CloseDose is a free dosing resource created by pediatric clinicians. When you donate, you help us update medication
+            guides, add new features families request, and keep the experience ad-free.
+          </p>
+          <p>
+            Choose the platform that works best for you—every gift directly fuels improvements that keep kids safe.
+          </p>
+        </section>
+
+        <section class="donation-grid" id="support-options" aria-label="Donation platforms">
+          <a
+            class="donation-card"
+            href="https://www.buymeacoffee.com/DrNSM"
+            target="_blank"
+            rel="noopener"
+            aria-label="Donate through Buy Me a Coffee"
+          >
+            <span class="donation-logo" aria-hidden="true">
+              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
+                <title>Buy Me a Coffee cup icon</title>
+                <g fill="none" stroke-width="6">
+                  <path
+                    class="outline"
+                    stroke="#0f2c2a"
+                    d="M24 34h72l-6 48a20 20 0 0 1-20 18H50a20 20 0 0 1-20-18l-6-48Z"
+                    fill="#fff"
+                  />
+                  <path
+                    stroke="#0f2c2a"
+                    d="M24 34h72v-8a6 6 0 0 0-6-6H30a6 6 0 0 0-6 6v8Z"
+                    fill="#0f2c2a"
+                  />
+                  <path fill="#f9cf23" stroke="#f9cf23" d="M36 54h48l-3.2 24a12 12 0 0 1-11.8 10H51a12 12 0 0 1-11.8-10L36 54Z" />
+                  <path
+                    stroke="#0f2c2a"
+                    d="M96 46h4a10 10 0 0 1 0 20h-6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </g>
+              </svg>
+            </span>
+            <span>Buy Me a Coffee</span>
+            <small>Quick, one-time boosts that power product updates.</small>
+          </a>
+
+          <a
+            class="donation-card"
+            href="https://gofund.me/e44df3954"
+            target="_blank"
+            rel="noopener"
+            aria-label="Donate through GoFundMe"
+          >
+            <span class="donation-logo" aria-hidden="true">
+              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
+                <title>GoFundMe sunrise icon</title>
+                <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path fill="#15a05c" stroke="#15a05c" stroke-width="6" d="M24 76a36 28 0 0 1 72 0Z" />
+                  <path stroke="#15a05c" stroke-width="7" d="M60 30v14" />
+                  <path stroke="#15a05c" stroke-width="7" d="m34 44 8 12" />
+                  <path stroke="#15a05c" stroke-width="7" d="m86 44-8 12" />
+                  <path stroke="#15a05c" stroke-width="7" d="M16 70h18" />
+                  <path stroke="#15a05c" stroke-width="7" d="M104 70H86" />
+                </g>
+              </svg>
+            </span>
+            <span>GoFundMe</span>
+            <small>Support long-term growth with a community campaign.</small>
+          </a>
+
+          <a
+            class="donation-card"
+            href="https://givebutter.com/93Xrjv"
+            target="_blank"
+            rel="noopener"
+            aria-label="Donate through Givebutter"
+          >
+            <span class="donation-logo" aria-hidden="true">
+              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
+                <title>Givebutter honeycomb icon</title>
+                <g fill="none" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="24" y="20" width="72" height="72" rx="26" fill="#ffcd2e" stroke="#ffcd2e" />
+                  <path
+                    d="M60 36c12 0 22 8 22 20s-10 20-22 20c-7 0-13-3-17-7"
+                    stroke="#2b1f0f"
+                    fill="none"
+                  />
+                  <path d="M43 66v8" stroke="#2b1f0f" />
+                  <path d="M52 44c2-6 8-10 14-10" stroke="#2b1f0f" />
+                </g>
+              </svg>
+            </span>
+            <span>Givebutter</span>
+            <small>Set up recurring support or dedicate a gift to someone special.</small>
+          </a>
+
+          <a
+            class="donation-card"
+            href="https://www.paypal.com/donate?campaign_id=8WB6G9RL72X2U"
+            target="_blank"
+            rel="noopener"
+            aria-label="Donate through PayPal"
+          >
+            <span class="donation-logo" aria-hidden="true">
+              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
+                <title>PayPal double P icon</title>
+                <g fill-rule="evenodd">
+                  <path
+                    d="M52 18h20c14 0 24 8 24 22 0 18-14 30-32 30h-8l-5 32H36Z"
+                    fill="#003087"
+                  />
+                  <path
+                    d="M44 26h18c14 0 22 8 22 20 0 16-12 26-28 26h-6l-5 32H32Z"
+                    fill="#009cde"
+                  />
+                </g>
+              </svg>
+            </span>
+            <span>PayPal</span>
+            <small>Give securely with PayPal using any major card or balance.</small>
+          </a>
+        </section>
+
+        <section class="impact-card" aria-labelledby="impact-heading">
+          <h2 id="impact-heading">How your donation helps</h2>
+          <ul>
+            <li>Expands our medication database with new visuals and dosing checks.</li>
+            <li>Keeps the calculator free from advertising or sponsored content.</li>
+            <li>Supports caregiver education resources shared by pediatric clinicians.</li>
+          </ul>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  <div class="menu-overlay" id="siteMenu" hidden>
+    <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">
+      <h2 id="menuHeading" class="visually-hidden">Site menu</h2>
+      <nav class="menu-links">
+        <a href="index.html">Calculator</a>
+        <a href="medication-guides.html">Medication Guides</a>
+        <a href="about.html">About</a>
+        <a href="donations.html" aria-current="page">Support CloseDose</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+      <button class="close-menu" type="button">Close</button>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      const menuButton = document.querySelector('.menu-btn');
+      const overlay = document.getElementById('siteMenu');
+      if (!menuButton || !overlay) {
+        return;
+      }
+      const closeButton = overlay.querySelector('.close-menu');
+      if (!closeButton) {
+        return;
+      }
+      const focusableSelector = 'a, button, [tabindex]:not([tabindex="-1"])';
+
+      function openMenu() {
+        menuButton.setAttribute('aria-expanded', 'true');
+        overlay.hidden = false;
+        overlay.classList.add('open');
+        const focusable = overlay.querySelectorAll(focusableSelector);
+        if (focusable.length) {
+          focusable[0].focus();
+        }
+        document.addEventListener('keydown', onKeyDown);
+      }
+
+      function closeMenu() {
+        menuButton.setAttribute('aria-expanded', 'false');
+        overlay.classList.remove('open');
+        const focusable = overlay.querySelectorAll(focusableSelector);
+        const lastFocused = document.activeElement;
+        overlay.addEventListener(
+          'transitionend',
+          () => {
+            overlay.hidden = true;
+            if (lastFocused && overlay.contains(lastFocused)) {
+              menuButton.focus();
+            }
+          },
+          { once: true }
+        );
+        document.removeEventListener('keydown', onKeyDown);
+      }
+
+      function onKeyDown(event) {
+        if (event.key === 'Escape') {
+          closeMenu();
+        }
+
+        if (event.key === 'Tab') {
+          const focusable = Array.from(overlay.querySelectorAll(focusableSelector));
+          if (!focusable.length) {
+            event.preventDefault();
+            return;
+          }
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      }
+
+      menuButton.addEventListener('click', () => {
+        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      closeButton.addEventListener('click', () => {
+        closeMenu();
+      });
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) {
+          closeMenu();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1062,6 +1062,7 @@
         <a href="index.html" aria-current="page">Calculator</a>
         <a href="medication-guides.html">Medication Guides</a>
         <a href="about.html">About</a>
+        <a href="donations.html">Support CloseDose</a>
         <a href="contact.html">Contact</a>
       </nav>
       <button class="close-menu" type="button">Close</button>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -850,9 +850,9 @@
         <a href="index.html">Calculator</a>
         <a href="medication-guides.html" aria-current="page">Medication Guides</a>
         <a href="about.html">About</a>
+        <a href="donations.html">Support CloseDose</a>
         <a href="contact.html">Contact</a>
         <a href="#" aria-disabled="true">Translate</a>
-        <a href="#" aria-disabled="true">Donate</a>
       </nav>
       <button class="close-menu" type="button">Close</button>
     </div>


### PR DESCRIPTION
## Summary
- add a new donations landing page with brand-aligned cards for Buy Me a Coffee, GoFundMe, Givebutter, and PayPal
- provide descriptive copy explaining how contributions sustain CloseDose resources
- expose the new Support CloseDose link inside the global menu across the site

## Testing
- python3 -m http.server 8000 (manual UI verification)


------
https://chatgpt.com/codex/tasks/task_e_68d790327ce483298b530749a87a9555