### PR TITLE
Center contact page info cards

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -400,6 +400,7 @@
       display: flex;
       flex-direction: column;
       gap: clamp(16px, 2.6vw, 24px);
+      align-items: center;
     }
 
     .info-card {
@@ -410,6 +411,7 @@
       box-shadow: var(--shadow-card);
       display: grid;
       gap: 10px;
+      width: min(100%, 420px);
     }
 
     .info-card h2 {


### PR DESCRIPTION
## Summary
- center the contact page info cards within their column for a balanced layout
- constrain the card width so the centered alignment looks consistent across screen sizes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80e7225fc83298b08ea13ee8d61fb