### PR TITLE
Update donation logos on support page

### DIFF
--- a/donations.html
+++ b/donations.html
@@ -288,12 +288,6 @@
       box-shadow: 0 0 0 4px rgba(36, 166, 135, 0.25), 0 22px 42px rgba(18, 58, 55, 0.18);
     }
 
-    .donation-card span {
-      font-size: 1.05rem;
-      font-weight: 700;
-      letter-spacing: 0.01em;
-    }
-
     .donation-card small {
       font-size: 0.95rem;
       color: var(--ink-700);
@@ -308,14 +302,9 @@
       background: var(--bg-accent);
     }
 
-    .donation-logo svg {
+    .donation-logo img {
       width: 70%;
-      height: 70%;
-    }
-
-    .donation-logo svg .outline {
-      stroke-linecap: round;
-      stroke-linejoin: round;
+      height: auto;
     }
 
     .impact-card {
@@ -480,31 +469,8 @@
             aria-label="Donate through Buy Me a Coffee"
           >
             <span class="donation-logo" aria-hidden="true">
-              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
-                <title>Buy Me a Coffee cup icon</title>
-                <g fill="none" stroke-width="6">
-                  <path
-                    class="outline"
-                    stroke="#0f2c2a"
-                    d="M24 34h72l-6 48a20 20 0 0 1-20 18H50a20 20 0 0 1-20-18l-6-48Z"
-                    fill="#fff"
-                  />
-                  <path
-                    stroke="#0f2c2a"
-                    d="M24 34h72v-8a6 6 0 0 0-6-6H30a6 6 0 0 0-6 6v8Z"
-                    fill="#0f2c2a"
-                  />
-                  <path fill="#f9cf23" stroke="#f9cf23" d="M36 54h48l-3.2 24a12 12 0 0 1-11.8 10H51a12 12 0 0 1-11.8-10L36 54Z" />
-                  <path
-                    stroke="#0f2c2a"
-                    d="M96 46h4a10 10 0 0 1 0 20h-6"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+              <img src="/Donations/buymeacoffee-stack-logo.png" alt="" />
             </span>
-            <span>Buy Me a Coffee</span>
             <small>Quick, one-time boosts that power product updates.</small>
           </a>
 
@@ -516,19 +482,8 @@
             aria-label="Donate through GoFundMe"
           >
             <span class="donation-logo" aria-hidden="true">
-              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
-                <title>GoFundMe sunrise icon</title>
-                <g fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path fill="#15a05c" stroke="#15a05c" stroke-width="6" d="M24 76a36 28 0 0 1 72 0Z" />
-                  <path stroke="#15a05c" stroke-width="7" d="M60 30v14" />
-                  <path stroke="#15a05c" stroke-width="7" d="m34 44 8 12" />
-                  <path stroke="#15a05c" stroke-width="7" d="m86 44-8 12" />
-                  <path stroke="#15a05c" stroke-width="7" d="M16 70h18" />
-                  <path stroke="#15a05c" stroke-width="7" d="M104 70H86" />
-                </g>
-              </svg>
+              <img src="/Donations/GFM-logo.png" alt="" />
             </span>
-            <span>GoFundMe</span>
             <small>Support long-term growth with a community campaign.</small>
           </a>
 
@@ -540,21 +495,8 @@
             aria-label="Donate through Givebutter"
           >
             <span class="donation-logo" aria-hidden="true">
-              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
-                <title>Givebutter honeycomb icon</title>
-                <g fill="none" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="24" y="20" width="72" height="72" rx="26" fill="#ffcd2e" stroke="#ffcd2e" />
-                  <path
-                    d="M60 36c12 0 22 8 22 20s-10 20-22 20c-7 0-13-3-17-7"
-                    stroke="#2b1f0f"
-                    fill="none"
-                  />
-                  <path d="M43 66v8" stroke="#2b1f0f" />
-                  <path d="M52 44c2-6 8-10 14-10" stroke="#2b1f0f" />
-                </g>
-              </svg>
+              <img src="/Donations/Givebutter-stack-logo.png" alt="" />
             </span>
-            <span>Givebutter</span>
             <small>Set up recurring support or dedicate a gift to someone special.</small>
           </a>
 
@@ -566,21 +508,8 @@
             aria-label="Donate through PayPal"
           >
             <span class="donation-logo" aria-hidden="true">
-              <svg viewBox="0 0 120 120" role="img" aria-hidden="true">
-                <title>PayPal double P icon</title>
-                <g fill-rule="evenodd">
-                  <path
-                    d="M52 18h20c14 0 24 8 24 22 0 18-14 30-32 30h-8l-5 32H36Z"
-                    fill="#003087"
-                  />
-                  <path
-                    d="M44 26h18c14 0 22 8 22 20 0 16-12 26-28 26h-6l-5 32H32Z"
-                    fill="#009cde"
-                  />
-                </g>
-              </svg>
+              <img src="/Donations/Paypal-stack-logo.png" alt="" />
             </span>
-            <span>PayPal</span>
             <small>Give securely with PayPal using any major card or balance.</small>
           </a>
         </section>


### PR DESCRIPTION
## Summary
- replace inline SVG logos on the donations page with provided stacked PNG assets
- remove redundant platform headings while keeping donation descriptions intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8189a69cc832994cf73be09e0ed8d