### PR TITLE
Update donate widget pig icon and fallback

### DIFF
--- a/about.html
+++ b/about.html
@@ -638,7 +638,7 @@
         </section>
 
         <section class="card impact-card">
-          <img src="images/PIGGYBANK-color.svg" alt="Piggy bank icon with coins" />
+          <img src="images/piggyFINAL.svg" alt="Piggy bank icon with coins" />
           <div>
             <h2>Community supported</h2>
             <p>

--- a/index.html
+++ b/index.html
@@ -1099,7 +1099,7 @@
                 data-gb-campaign="93XRJV"
               >
                 <span>Please Donate!</span>
-                <img src="images/PIGGYBANK-color.svg" alt="" aria-hidden="true" />
+                <img src="images/piggyFINAL.svg" alt="" aria-hidden="true" />
               </button>
             </div>
             <p class="donate-intro">
@@ -1248,6 +1248,37 @@
           first.focus();
         }
       });
+
+      const donateButton = document.querySelector('.donate-pill[data-gb-account][data-gb-campaign]');
+      if (donateButton) {
+        const fallbackUrl = 'https://givebutter.com/93Xrjv';
+        donateButton.setAttribute('data-fallback-href', fallbackUrl);
+
+        const isGivebutterReady = () => {
+          const givebutter = window.Givebutter;
+          if (!givebutter) {
+            return false;
+          }
+          if (typeof givebutter === 'function') {
+            return true;
+          }
+          if (typeof givebutter === 'object') {
+            if (typeof givebutter.Widget === 'function') {
+              return true;
+            }
+            if (typeof givebutter.open === 'function') {
+              return true;
+            }
+          }
+          return false;
+        };
+
+        donateButton.addEventListener('click', () => {
+          if (!isGivebutterReady()) {
+            window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
+          }
+        });
+      }
 
       updateMenuPresentation();
       window.addEventListener('scroll', updateMenuPresentation, { passive: true });


### PR DESCRIPTION
## Summary
- replace the donate pig graphic with the new `piggyFINAL.svg` asset on the homepage and about page
- add a Givebutter fallback link that opens the campaign in a new tab if the widget script is unavailable

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc6750e03083298e20e2f623d6dbb3