### PR TITLE
Add responsive CloseDose footer across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -44,6 +44,11 @@
       --card-radius: 26px;
       --shadow-card: 0 10px 32px rgba(18, 58, 55, 0.14);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -416,21 +421,110 @@
       line-height: 1.7;
     }
 
-    footer {
-      padding: 24px clamp(18px, 5vw, 52px) 48px;
-      font-size: 0.9rem;
-      line-height: 1.5;
-      text-align: center;
-      color: var(--teal-600);
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
     }
 
-    footer small {
-      display: block;
-      max-width: 960px;
-      margin: 0 auto;
-      font-size: 0.78rem;
-      letter-spacing: 0.02em;
-      color: var(--teal-500);
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
     }
 
     .menu-overlay {
@@ -662,10 +756,38 @@
     </main>
   </div>
 
-  <footer>
-    <p>&copy; <span id="year"></span> CloseDose. All rights reserved.</p>
-    <small>CloseDose is an educational resource and is not a substitute for personalized medical advice.</small>
-  </footer>
+    <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+      <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+      <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+
+      <details class="cd-legal cd-legal--accordion">
+        <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+        <nav id="legal-links" aria-label="Legal and policy links">
+          <a href="/legal/terms">Terms of Use</a>
+          <a href="/legal/privacy">Privacy Policy</a>
+          <a href="/legal/disclaimer">Disclaimer</a>
+          <a href="/legal/aup">Acceptable Use</a>
+          <a href="/legal/dmca">DMCA Policy</a>
+        </nav>
+      </details>
+
+      <p class="cd-note">
+        For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+        advice.
+      </p>
+
+      <p class="cd-contact">
+        Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+        <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+      </p>
+    </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/contact.html
+++ b/contact.html
@@ -48,6 +48,11 @@
       --shadow-card: 0 10px 32px rgba(18, 58, 55, 0.14);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.22);
       --text-muted: rgba(15, 44, 42, 0.72);
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -536,6 +541,112 @@
       outline: 3px solid #222;
       outline-offset: 3px;
     }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
+    }
+
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
+    }
   </style>
 </head>
 <body>
@@ -639,6 +750,39 @@
       </div>
     </main>
   </div>
+
+  <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+    <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+    <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+      <a href="/legal/terms">Terms of Use</a>
+      <a href="/legal/privacy">Privacy Policy</a>
+      <a href="/legal/disclaimer">Disclaimer</a>
+      <a href="/legal/aup">Acceptable Use</a>
+      <a href="/legal/dmca">DMCA Policy</a>
+    </nav>
+
+    <details class="cd-legal cd-legal--accordion">
+      <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+      <nav id="legal-links" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+    </details>
+
+    <p class="cd-note">
+      For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+      advice.
+    </p>
+
+    <p class="cd-contact">
+      Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+      <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+    </p>
+  </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/donations.html
+++ b/donations.html
@@ -49,6 +49,11 @@
       --card-radius: 26px;
       --shadow-card: 0 14px 42px rgba(18, 58, 55, 0.15);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.2);
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -417,16 +422,122 @@
       }
     }
 
-    @media (max-width: 640px) {
-      main {
-        padding: 24px clamp(14px, 6vw, 24px) 80px;
+      @media (max-width: 640px) {
+        main {
+          padding: 24px clamp(14px, 6vw, 24px) 80px;
+        }
+
+        header {
+          background: transparent !important;
+          padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px);
+        }
       }
 
-      header {
-        background: transparent !important;
-        padding: clamp(10px, 3vw, 18px) clamp(16px, 6vw, 28px) clamp(4px, 2vw, 12px);
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --footer-bg: #0d1b2a;
+          --footer-fg: #eaeaea;
+          --footer-muted: #a8b3bd;
+          --footer-link: #4dd0e1;
+          --footer-border: #1b263b;
+        }
       }
-    }
+
+      .cd-footer {
+        background: var(--footer-bg);
+        color: var(--footer-fg);
+        border-top: 1px solid var(--footer-border);
+        padding: 1.25rem min(5vw, 1.25rem);
+        text-align: center;
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+
+      .cd-footer a {
+        color: var(--footer-link);
+        text-decoration: none;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        display: inline-block;
+      }
+
+      .cd-footer a:hover,
+      .cd-footer a:focus-visible {
+        text-decoration: underline;
+        outline: none;
+      }
+
+      .cd-copy {
+        margin: 0 0 0.5rem;
+        font-weight: 600;
+      }
+
+      .cd-note {
+        margin: 0.75rem auto 0;
+        max-width: 60ch;
+        color: var(--footer-muted);
+        font-size: 0.85rem;
+      }
+
+      .cd-contact {
+        margin: 0.75rem 0 0;
+        font-size: 0.9rem;
+      }
+
+      .cd-legal--full {
+        margin: 0.35rem auto 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 0.25rem;
+        justify-content: center;
+      }
+
+      .cd-legal--accordion {
+        margin: 0.35rem auto 0;
+        max-width: 22rem;
+        text-align: left;
+      }
+
+      .cd-legal--accordion summary {
+        cursor: pointer;
+        font-weight: 600;
+        list-style: none;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        background: transparent;
+        color: var(--footer-link);
+      }
+
+      .cd-legal--accordion summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .cd-legal--accordion[open] summary {
+        text-decoration: underline;
+      }
+
+      .cd-legal--accordion nav {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 0.25rem 0.75rem 0.5rem;
+      }
+
+      @media (min-width: 640px) {
+        .cd-legal--accordion {
+          display: none;
+        }
+      }
+
+      @media (max-width: 639px) {
+        .cd-legal--full {
+          display: none;
+        }
+
+        .cd-note {
+          font-size: 0.8rem;
+        }
+      }
   </style>
 </head>
 <body>
@@ -531,6 +642,39 @@
       </div>
     </main>
   </div>
+
+  <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+    <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+    <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+      <a href="/legal/terms">Terms of Use</a>
+      <a href="/legal/privacy">Privacy Policy</a>
+      <a href="/legal/disclaimer">Disclaimer</a>
+      <a href="/legal/aup">Acceptable Use</a>
+      <a href="/legal/dmca">DMCA Policy</a>
+    </nav>
+
+    <details class="cd-legal cd-legal--accordion">
+      <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+      <nav id="legal-links" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+    </details>
+
+    <p class="cd-note">
+      For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+      advice.
+    </p>
+
+    <p class="cd-contact">
+      Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+      <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+    </p>
+  </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/index-es.html
+++ b/index-es.html
@@ -31,6 +31,11 @@
       --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
       --pill-max-width: 720px;
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -833,21 +838,110 @@
       color: var(--teal-600);
     }
 
-    footer {
-      padding: 24px clamp(18px, 5vw, 52px) 48px;
-      font-size: 0.9rem;
-      line-height: 1.5;
-      text-align: center;
-      color: var(--teal-600);
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
     }
 
-    footer small {
-      display: block;
-      max-width: 960px;
-      margin: 0 auto;
-      font-size: 0.78rem;
-      letter-spacing: 0.02em;
-      color: var(--teal-500);
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
     }
 
     /* Overlay menu */
@@ -1053,6 +1147,39 @@
       </div>
     </main>
   </div>
+
+  <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+    <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+    <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+      <a href="/legal/terms">Terms of Use</a>
+      <a href="/legal/privacy">Privacy Policy</a>
+      <a href="/legal/disclaimer">Disclaimer</a>
+      <a href="/legal/aup">Acceptable Use</a>
+      <a href="/legal/dmca">DMCA Policy</a>
+    </nav>
+
+    <details class="cd-legal cd-legal--accordion">
+      <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+      <nav id="legal-links" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+    </details>
+
+    <p class="cd-note">
+      For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+      advice.
+    </p>
+
+    <p class="cd-contact">
+      Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+      <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+    </p>
+  </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/index-fr.html
+++ b/index-fr.html
@@ -31,6 +31,11 @@
       --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
       --pill-max-width: 720px;
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -833,21 +838,110 @@
       color: var(--teal-600);
     }
 
-    footer {
-      padding: 24px clamp(18px, 5vw, 52px) 48px;
-      font-size: 0.9rem;
-      line-height: 1.5;
-      text-align: center;
-      color: var(--teal-600);
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
     }
 
-    footer small {
-      display: block;
-      max-width: 960px;
-      margin: 0 auto;
-      font-size: 0.78rem;
-      letter-spacing: 0.02em;
-      color: var(--teal-500);
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
     }
 
     /* Overlay menu */
@@ -1053,6 +1147,39 @@
       </div>
     </main>
   </div>
+
+  <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+    <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+    <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+      <a href="/legal/terms">Terms of Use</a>
+      <a href="/legal/privacy">Privacy Policy</a>
+      <a href="/legal/disclaimer">Disclaimer</a>
+      <a href="/legal/aup">Acceptable Use</a>
+      <a href="/legal/dmca">DMCA Policy</a>
+    </nav>
+
+    <details class="cd-legal cd-legal--accordion">
+      <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+      <nav id="legal-links" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+    </details>
+
+    <p class="cd-note">
+      For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+      advice.
+    </p>
+
+    <p class="cd-contact">
+      Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+      <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+    </p>
+  </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/index-pt.html
+++ b/index-pt.html
@@ -31,6 +31,11 @@
       --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
       --pill-max-width: 720px;
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -833,21 +838,110 @@
       color: var(--teal-600);
     }
 
-    footer {
-      padding: 24px clamp(18px, 5vw, 52px) 48px;
-      font-size: 0.9rem;
-      line-height: 1.5;
-      text-align: center;
-      color: var(--teal-600);
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
     }
 
-    footer small {
-      display: block;
-      max-width: 960px;
-      margin: 0 auto;
-      font-size: 0.78rem;
-      letter-spacing: 0.02em;
-      color: var(--teal-500);
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
     }
 
     /* Overlay menu */
@@ -1053,6 +1147,39 @@
       </div>
     </main>
   </div>
+
+  <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+    <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+    <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+      <a href="/legal/terms">Terms of Use</a>
+      <a href="/legal/privacy">Privacy Policy</a>
+      <a href="/legal/disclaimer">Disclaimer</a>
+      <a href="/legal/aup">Acceptable Use</a>
+      <a href="/legal/dmca">DMCA Policy</a>
+    </nav>
+
+    <details class="cd-legal cd-legal--accordion">
+      <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+      <nav id="legal-links" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+    </details>
+
+    <p class="cd-note">
+      For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+      advice.
+    </p>
+
+    <p class="cd-contact">
+      Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+      <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+    </p>
+  </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/index.html
+++ b/index.html
@@ -32,6 +32,11 @@
       --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
       --pill-max-width: 720px;
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -920,21 +925,110 @@
       color: var(--teal-600);
     }
 
-    footer {
-      padding: 24px clamp(18px, 5vw, 52px) 48px;
-      font-size: 0.9rem;
-      line-height: 1.5;
-      text-align: center;
-      color: var(--teal-600);
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
     }
 
-    footer small {
-      display: block;
-      max-width: 960px;
-      margin: 0 auto;
-      font-size: 0.78rem;
-      letter-spacing: 0.02em;
-      color: var(--teal-500);
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
     }
 
     /* Overlay menu */
@@ -1152,6 +1246,39 @@
       </div>
     </main>
   </div>
+
+  <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+    <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+    <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+      <a href="/legal/terms">Terms of Use</a>
+      <a href="/legal/privacy">Privacy Policy</a>
+      <a href="/legal/disclaimer">Disclaimer</a>
+      <a href="/legal/aup">Acceptable Use</a>
+      <a href="/legal/dmca">DMCA Policy</a>
+    </nav>
+
+    <details class="cd-legal cd-legal--accordion">
+      <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+      <nav id="legal-links" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+    </details>
+
+    <p class="cd-note">
+      For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical
+      advice.
+    </p>
+
+    <p class="cd-contact">
+      Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+      <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+    </p>
+  </footer>
 
   <div class="menu-overlay" id="siteMenu" hidden>
     <div class="menu-panel" role="dialog" aria-modal="true" aria-labelledby="menuHeading">

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -43,6 +43,11 @@
       --shadow-card: 0 6px 0 rgba(15, 44, 42, 0.18);
       --shadow-btn: 0 4px 0 rgba(15, 44, 42, 0.25);
       --shadow-pill: var(--shadow-btn);
+      --footer-bg: #f8f9fa;
+      --footer-fg: #111111;
+      --footer-muted: #666666;
+      --footer-link: #0369a1;
+      --footer-border: #e5e7eb;
     }
 
     *,
@@ -527,21 +532,110 @@
       gap: 6px;
     }
 
-    footer {
-      padding: 24px clamp(18px, 5vw, 52px) 48px;
-      font-size: 0.9rem;
-      line-height: 1.5;
-      text-align: center;
-      color: var(--teal-600);
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --footer-bg: #0d1b2a;
+        --footer-fg: #eaeaea;
+        --footer-muted: #a8b3bd;
+        --footer-link: #4dd0e1;
+        --footer-border: #1b263b;
+      }
     }
 
-    footer small {
-      display: block;
-      max-width: 960px;
-      margin: 0 auto;
-      font-size: 0.78rem;
-      letter-spacing: 0.02em;
-      color: var(--teal-500);
+    .cd-footer {
+      background: var(--footer-bg);
+      color: var(--footer-fg);
+      border-top: 1px solid var(--footer-border);
+      padding: 1.25rem min(5vw, 1.25rem);
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+
+    .cd-footer a {
+      color: var(--footer-link);
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      display: inline-block;
+    }
+
+    .cd-footer a:hover,
+    .cd-footer a:focus-visible {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .cd-copy {
+      margin: 0 0 0.5rem;
+      font-weight: 600;
+    }
+
+    .cd-note {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--footer-muted);
+      font-size: 0.85rem;
+    }
+
+    .cd-contact {
+      margin: 0.75rem 0 0;
+      font-size: 0.9rem;
+    }
+
+    .cd-legal--full {
+      margin: 0.35rem auto 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem 0.25rem;
+      justify-content: center;
+    }
+
+    .cd-legal--accordion {
+      margin: 0.35rem auto 0;
+      max-width: 22rem;
+      text-align: left;
+    }
+
+    .cd-legal--accordion summary {
+      cursor: pointer;
+      font-weight: 600;
+      list-style: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--footer-link);
+    }
+
+    .cd-legal--accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cd-legal--accordion[open] summary {
+      text-decoration: underline;
+    }
+
+    .cd-legal--accordion nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem 0.5rem;
+    }
+
+    @media (min-width: 640px) {
+      .cd-legal--accordion {
+        display: none;
+      }
+    }
+
+    @media (max-width: 639px) {
+      .cd-legal--full {
+        display: none;
+      }
+
+      .cd-note {
+        font-size: 0.8rem;
+      }
     }
 
     /* Overlay menu */
@@ -841,12 +935,37 @@
     </div>
   </div>
 
-  <footer>
-    <small>
-      Disclaimer: This tool is for educational purposes only and is not a substitute for professional medical advice. Always confirm dosing with your pediatrician or pharmacist before administering medication.
-      <br />Updated 9.22.2025 • Nickolas Mancini, MD, MBA
-    </small>
-  </footer>
+    <footer class="cd-footer" role="contentinfo" aria-label="Site footer">
+      <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
+
+      <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
+        <a href="/legal/terms">Terms of Use</a>
+        <a href="/legal/privacy">Privacy Policy</a>
+        <a href="/legal/disclaimer">Disclaimer</a>
+        <a href="/legal/aup">Acceptable Use</a>
+        <a href="/legal/dmca">DMCA Policy</a>
+      </nav>
+
+      <details class="cd-legal cd-legal--accordion">
+        <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
+        <nav id="legal-links" aria-label="Legal and policy links">
+          <a href="/legal/terms">Terms of Use</a>
+          <a href="/legal/privacy">Privacy Policy</a>
+          <a href="/legal/disclaimer">Disclaimer</a>
+          <a href="/legal/aup">Acceptable Use</a>
+          <a href="/legal/dmca">DMCA Policy</a>
+        </nav>
+      </details>
+
+      <p class="cd-note">
+        For medical emergencies, call 911. This site is for educational purposes only and not a substitute for professional medical advice.
+      </p>
+
+      <p class="cd-contact">
+        Contact: <a href="mailto:info@closedose.com">info@closedose.com</a> •
+        <a href="mailto:hello@closedose.com">hello@closedose.com</a>
+      </p>
+    </footer>
 
   <div class="translation-overlay" id="translationOverlay" hidden aria-hidden="true">
     <div class="translation-modal" role="dialog" aria-modal="true" aria-labelledby="translationHeading">

--- a/style.css
+++ b/style.css
@@ -10,6 +10,11 @@
   --primary-strong: #081c29;
   --text-light: #0b2136;
   --text-muted: rgba(15, 46, 68, 0.7);
+  --footer-bg: #f8f9fa;
+  --footer-fg: #111111;
+  --footer-muted: #666666;
+  --footer-link: #0369a1;
+  --footer-border: #e5e7eb;
   color-scheme: light;
 }
 
@@ -701,19 +706,110 @@ button:focus-visible {
   transform: scale(1.1);
 }
 
-footer {
-  padding: 16px;
+.cd-footer {
+  background: var(--footer-bg);
+  color: var(--footer-fg);
+  border-top: 1px solid var(--footer-border);
+  padding: 1.25rem min(5vw, 1.25rem);
   text-align: center;
-  background-color: rgba(223, 240, 250, 0.86);
-  font-size: 0.9rem;
-  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
 }
 
-footer small {
-  display: block;
-  font-size: 0.78rem;
-  letter-spacing: 0.02em;
-  color: inherit;
+.cd-footer a {
+  color: var(--footer-link);
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  display: inline-block;
+}
+
+.cd-footer a:hover,
+.cd-footer a:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.cd-copy {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.cd-note {
+  margin: 0.75rem auto 0;
+  max-width: 60ch;
+  color: var(--footer-muted);
+  font-size: 0.85rem;
+}
+
+.cd-contact {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+}
+
+.cd-legal--full {
+  margin: 0.35rem auto 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.25rem;
+  justify-content: center;
+}
+
+.cd-legal--accordion {
+  margin: 0.35rem auto 0;
+  max-width: 22rem;
+  text-align: left;
+}
+
+.cd-legal--accordion summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--footer-link);
+}
+
+.cd-legal--accordion summary::-webkit-details-marker {
+  display: none;
+}
+
+.cd-legal--accordion[open] summary {
+  text-decoration: underline;
+}
+
+.cd-legal--accordion nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.25rem 0.75rem 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --footer-bg: #0d1b2a;
+    --footer-fg: #eaeaea;
+    --footer-muted: #a8b3bd;
+    --footer-link: #4dd0e1;
+    --footer-border: #1b263b;
+  }
+}
+
+@media (min-width: 640px) {
+  .cd-legal--accordion {
+    display: none;
+  }
+}
+
+@media (max-width: 639px) {
+  .cd-legal--full {
+    display: none;
+  }
+
+  .cd-note {
+    font-size: 0.8rem;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add shared cd-footer styling with dark-mode friendly colors, responsive legal navigation, and accessible link spacing
- replace existing footers across calculator, localized, about, donations, contact, and medication guide pages with the new structure and messaging

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68df9534d968832992b0a0d947f31550