### PR TITLE
Add GA4 tracking to landing pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,6 +21,17 @@
   <meta name="twitter:description" content="Discover the mission behind CloseDose and how we support safe pediatric medication dosing." />
   <meta name="twitter:image" content="images/og-2400.png" />
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
+
   <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16.png">
   <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32.png">
   <link rel="icon" type="image/png" sizes="192x192" href="images/favicon-192.png">
@@ -862,6 +873,38 @@
         yearEl.textContent = new Date().getFullYear();
       }
     })();
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase();
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase();
+
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+
+    track('tag_visit', { src: SRC, id: ID });
+
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
+    });
   </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -27,6 +27,17 @@
   <link rel="apple-touch-icon" href="/logo-dark.svg" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#24a687">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
+
   <script
   async
   src="https://widgets.givebutter.com/latest.umd.cjs?acct=r8SGiZ0RhFRoIkXu&p=other"
@@ -1007,6 +1018,39 @@
         statusEl.textContent = 'Thanks! We’ll respond as soon as we can.';
       });
     })();
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase();
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase();
+
+    // Helper to fire GA4 events
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+    // Log the visit itself (one event per load)
+    track('tag_visit', { src: SRC, id: ID });
+    // Wire up main actions (adjust selectors to your actual buttons/links)
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+    // Optional: generic auto-tracking for any link with data-use="…"
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
+    });
   </script>
 </body>
 </html>

--- a/donations.html
+++ b/donations.html
@@ -32,6 +32,16 @@
   <link rel="apple-touch-icon" href="/logo-light.svg">
   <link rel="apple-touch-icon" href="/logo-dark.svg" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#24a687">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
   <script async src="https://widgets.givebutter.com/latest.umd.cjs?acct=r8SGiZ0RhFRoIkXu&p=other"></script>
 
   <style>
@@ -626,7 +636,7 @@
           </ul>
         </section>
         <section> 
-          <button class="donate-pill" type="button" data-gb-account="r8SGiZ0RhFRoIkXu" data-gb-campaign="93Xrjv" data-fallback-href="https://givebutter.com/93Xrjv" data-gb-processed="true">
+          <button class="donate-pill" type="button" id="donateBtn" data-gb-account="r8SGiZ0RhFRoIkXu" data-gb-campaign="93Xrjv" data-fallback-href="https://givebutter.com/93Xrjv" data-gb-processed="true">
           <givebutter-widget id="LYXNmj"></givebutter-widget><span>Please Donate to Support CloseDose Today!!</span>
            <img src="images/piggyFINAL.svg" alt="" aria-hidden="true">
          </button>
@@ -766,5 +776,38 @@
       }
     })();
   </script>
+    <script>
+      // Read simple tracking params from the URL
+      const u = new URL(location.href);
+      const SRC = (u.searchParams.get('src') || 'na').toLowerCase(); // nfc | qr | link
+      const ID = (u.searchParams.get('id') || 'na').toLowerCase(); // 01..22 or short label
+
+      // Helper to fire GA4 events
+      function track(event, params = {}) {
+        if (window.gtag) gtag('event', event, params);
+      }
+      // Log the visit itself (one event per load)
+      track('tag_visit', { src: SRC, id: ID });
+      // Wire up main actions (adjust selectors to your actual buttons/links)
+      document.getElementById('calcBtn')?.addEventListener('click', () =>
+        track('tag_use', { use: 'calc', src: SRC, id: ID })
+      );
+      document.getElementById('handoutBtn')?.addEventListener('click', () =>
+        track('tag_use', { use: 'handout', src: SRC, id: ID })
+      );
+      document.getElementById('donateBtn')?.addEventListener('click', () =>
+        track('tag_use', { use: 'donate', src: SRC, id: ID })
+      );
+      // Optional: generic auto-tracking for any link with data-use="…"
+      document.querySelectorAll('a[data-use]').forEach((a) => {
+        a.addEventListener('click', () =>
+          track('tag_use', {
+            use: a.getAttribute('data-use'),
+            src: SRC,
+            id: ID,
+          })
+        );
+      });
+    </script>
 </body>
 </html>

--- a/index-es.html
+++ b/index-es.html
@@ -15,6 +15,16 @@
   <meta property="og:image" content="/images/OG-image.png">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
   <style>
     :root {
       --teal-400: #24a687;
@@ -1475,6 +1485,39 @@
           setDisclaimerState(false, { manual: true });
         }
       });
+    });
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase();
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase();
+
+    // Helper to fire GA4 events
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+    // Log the visit itself (one event per load)
+    track('tag_visit', { src: SRC, id: ID });
+    // Wire up main actions (adjust selectors to your actual buttons/links)
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+    // Optional: generic auto-tracking for any link with data-use="…"
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
     });
   </script>
 </body>

--- a/index-fr.html
+++ b/index-fr.html
@@ -15,6 +15,16 @@
   <meta property="og:image" content="/images/OG-image.png">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
   <style>
     :root {
       --teal-400: #24a687;
@@ -1475,6 +1485,39 @@
           setDisclaimerState(false, { manual: true });
         }
       });
+    });
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase();
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase();
+
+    // Helper to fire GA4 events
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+    // Log the visit itself (one event per load)
+    track('tag_visit', { src: SRC, id: ID });
+    // Wire up main actions (adjust selectors to your actual buttons/links)
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+    // Optional: generic auto-tracking for any link with data-use="…"
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
     });
   </script>
 </body>

--- a/index-pt.html
+++ b/index-pt.html
@@ -15,6 +15,16 @@
   <meta property="og:image" content="/images/OG-image.png">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
   <style>
     :root {
       --teal-400: #24a687;
@@ -1475,6 +1485,39 @@
           setDisclaimerState(false, { manual: true });
         }
       });
+    });
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase();
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase();
+
+    // Helper to fire GA4 events
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+    // Log the visit itself (one event per load)
+    track('tag_visit', { src: SRC, id: ID });
+    // Wire up main actions (adjust selectors to your actual buttons/links)
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+    // Optional: generic auto-tracking for any link with data-use="…"
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,16 @@
   <meta property="og:image" content="/images/OG-image.png">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:alt" content="CloseDose pediatric dosing calculator preview">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
   <script async src="https://widgets.givebutter.com/latest.umd.cjs?acct=r8SGiZ0RhFRoIkXu&p=other"></script>
   <style>
     :root {
@@ -1145,9 +1155,10 @@
             <div class="donate-primary">
             <div></div>
                <button 
-               class="donate-pill" 
-               type="button" 
-               data-gb-account="r8SGiZ0RhFRoIkXu" 
+               class="donate-pill"
+               type="button"
+               id="donateBtn"
+               data-gb-account="r8SGiZ0RhFRoIkXu"
                data-gb-campaign="93Xrjv" 
                 data-fallback-href="https://givebutter.com/93Xrjv">
                 <span>Powered by Parents! Please Consider Donating Today!!!</span>
@@ -1519,6 +1530,39 @@
           setDisclaimerState(false, { manual: true });
         }
       });
+    });
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase(); // nfc | qr | link
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase(); // 01..22 or short label
+
+    // Helper to fire GA4 events
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+    // Log the visit itself (one event per load)
+    track('tag_visit', { src: SRC, id: ID });
+    // Wire up main actions (adjust selectors to your actual buttons/links)
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+    // Optional: generic auto-tracking for any link with data-use="…"
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
     });
   </script>
 </body>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -27,6 +27,17 @@
   <link rel="apple-touch-icon" href="/logo-dark.svg" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#24a687">
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WYY1QFRPYP"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-WYY1QFRPYP');
+  </script>
+
   <style>
     :root {
       --teal-300: #3ec0ab;
@@ -1064,6 +1075,39 @@
       }
     })();
 
+  </script>
+  <script>
+    // Read simple tracking params from the URL
+    const u = new URL(location.href);
+    const SRC = (u.searchParams.get('src') || 'na').toLowerCase();
+    const ID = (u.searchParams.get('id') || 'na').toLowerCase();
+
+    // Helper to fire GA4 events
+    function track(event, params = {}) {
+      if (window.gtag) gtag('event', event, params);
+    }
+    // Log the visit itself (one event per load)
+    track('tag_visit', { src: SRC, id: ID });
+    // Wire up main actions (adjust selectors to your actual buttons/links)
+    document.getElementById('calcBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'calc', src: SRC, id: ID })
+    );
+    document.getElementById('handoutBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'handout', src: SRC, id: ID })
+    );
+    document.getElementById('donateBtn')?.addEventListener('click', () =>
+      track('tag_use', { use: 'donate', src: SRC, id: ID })
+    );
+    // Optional: generic auto-tracking for any link with data-use="…"
+    document.querySelectorAll('a[data-use]').forEach((a) => {
+      a.addEventListener('click', () =>
+        track('tag_use', {
+          use: a.getAttribute('data-use'),
+          src: SRC,
+          id: ID,
+        })
+      );
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the GA4 tag snippet to the primary calculator landing page and localized variants
- hook GA4 event tracking on secondary entry pages (about, contact, donations, medication guides) including the donate button id

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e229ea416c8329b4674d4443231b40