### PR TITLE
Refine calculator age button layout and centering

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -232,7 +232,7 @@
     }
 
     .layout {
-      width: min(820px, 100%);
+      width: min(760px, 100%);
       margin: 0 auto;
       display: flex;
       flex-direction: column;
@@ -247,8 +247,8 @@
       box-shadow: var(--shadow-card);
       padding: clamp(24px, 4vw, 36px);
       width: 100%;
-      max-width: min(760px, 100%);
-      margin: 0;
+      max-width: min(720px, 100%);
+      margin: 0 auto;
     }
 
     .card.card--calculator,
@@ -259,6 +259,8 @@
 
     .calculator-widget-host {
       width: 100%;
+      max-width: 720px;
+      margin: 0 auto;
     }
 
     .donate-card {
@@ -1162,23 +1164,25 @@
           strings: {
             title: 'Calculadora de Medicamentos para Fiebre/Dolor',
             form: {
-              ageLabel: 'Edad del paciente',
+              ageLabel: 'Paso 1: Toque el grupo de edad',
               ageGroupAria: 'Seleccionar edad del paciente',
-              agePrompt: '¡Bienvenido! Elige un grupo de edad para comenzar.',
+              agePrompt: 'Paso 1: ¡Elige un grupo de edad para comenzar!',
               ageOptions: {
-                '0-2': '0-2 meses',
-                '2-6': '2-6 meses',
-                '6-24': '6-24 meses',
-                '2y+': '2+ años',
+                '0-2': { primary: '0 meses', secondary: '2 meses', align: 'start', accessible: '0 a 2 meses' },
+                '2-6': { primary: '2 meses', secondary: '6 meses', align: 'start', accessible: '2 a 6 meses' },
+                '6-11': { primary: '6 meses', secondary: '11 años', align: 'start', accessible: '6 meses a 11 años' },
+                '12+': { primary: '12 años', secondary: 'o más', align: 'center', accessible: '12 años o más' },
+                '2y+': { primary: '12 años', secondary: 'o más', align: 'center', accessible: '12 años o más' },
               },
               ageSelectLabel: 'Seleccione la edad',
               infantCriticalMessage:
                 '<strong>Busque atención médica inmediata.</strong> Si un niño menor de 60 días tiene fiebre es una emergencia médica. Comuníquese con su pediatra o busque atención con un profesional de la salud de inmediato.',
-              weightLabel: 'Peso del paciente',
+              weightLabel: 'Paso 2: Introducir peso',
               weightInputLabel: 'Introducir peso',
               weightPlaceholder: 'Introducir peso',
               weightUnitAria: 'Seleccionar unidad de peso',
               calculate: 'Calcular',
+              calculateStep: 'Paso 3: ¡Calcular!',
             },
             units: {
               lbs: 'lbs',

--- a/index-fr.html
+++ b/index-fr.html
@@ -232,7 +232,7 @@
     }
 
     .layout {
-      width: min(820px, 100%);
+      width: min(760px, 100%);
       margin: 0 auto;
       display: flex;
       flex-direction: column;
@@ -247,8 +247,8 @@
       box-shadow: var(--shadow-card);
       padding: clamp(24px, 4vw, 36px);
       width: 100%;
-      max-width: min(760px, 100%);
-      margin: 0;
+      max-width: min(720px, 100%);
+      margin: 0 auto;
     }
 
     .card.card--calculator,
@@ -259,6 +259,8 @@
 
     .calculator-widget-host {
       width: 100%;
+      max-width: 720px;
+      margin: 0 auto;
     }
 
     .donate-card {
@@ -1162,23 +1164,25 @@
           strings: {
             title: 'Calculatrice de médicaments pour fièvre/douleur',
             form: {
-              ageLabel: 'Âge du patient',
+              ageLabel: "Étape 1 : Touchez le groupe d’âge",
               ageGroupAria: "Sélectionner l’âge du patient",
-              agePrompt: "Bienvenue ! Choisissez un groupe d’âge pour commencer.",
+              agePrompt: "Étape 1 : Choisissez un groupe d’âge pour commencer.",
               ageOptions: {
-                '0-2': '0-2 mois',
-                '2-6': '2-6 mois',
-                '6-24': '6-24 mois',
-                '2y+': '2 ans ou plus',
+                '0-2': { primary: '0 mois', secondary: '2 mois', align: 'start', accessible: '0 à 2 mois' },
+                '2-6': { primary: '2 mois', secondary: '6 mois', align: 'start', accessible: '2 à 6 mois' },
+                '6-11': { primary: '6 mois', secondary: '11 ans', align: 'start', accessible: '6 mois à 11 ans' },
+                '12+': { primary: '12 ans', secondary: 'et plus', align: 'center', accessible: '12 ans et plus' },
+                '2y+': { primary: '12 ans', secondary: 'et plus', align: 'center', accessible: '12 ans et plus' },
               },
               ageSelectLabel: "Sélectionnez l’âge",
               infantCriticalMessage:
                 "<strong>Consultez immédiatement un médecin.</strong> Si un enfant de moins de 60 jours a de la fièvre, il s’agit d’une urgence médicale. Veuillez contacter votre pédiatre ou consulter un professionnel de santé immédiatement.",
-              weightLabel: 'Poids du patient',
+              weightLabel: 'Étape 2 : Saisir le poids',
               weightInputLabel: 'Saisir le poids',
               weightPlaceholder: 'Saisir le poids',
               weightUnitAria: "Sélectionner l’unité de poids",
               calculate: 'Calculer',
+              calculateStep: 'Étape 3 : Calculer !',
             },
             units: {
               lbs: 'lbs',

--- a/index-pt.html
+++ b/index-pt.html
@@ -232,7 +232,7 @@
     }
 
     .layout {
-      width: min(820px, 100%);
+      width: min(760px, 100%);
       margin: 0 auto;
       display: flex;
       flex-direction: column;
@@ -247,8 +247,8 @@
       box-shadow: var(--shadow-card);
       padding: clamp(24px, 4vw, 36px);
       width: 100%;
-      max-width: min(760px, 100%);
-      margin: 0;
+      max-width: min(720px, 100%);
+      margin: 0 auto;
     }
 
     .card.card--calculator,
@@ -259,6 +259,8 @@
 
     .calculator-widget-host {
       width: 100%;
+      max-width: 720px;
+      margin: 0 auto;
     }
 
     .donate-card {
@@ -1162,23 +1164,25 @@
           strings: {
             title: 'Calculadora de Medicamentos para Febre/Dor',
             form: {
-              ageLabel: 'Idade do paciente',
+              ageLabel: 'Passo 1: Toque o grupo etário',
               ageGroupAria: 'Selecionar idade do paciente',
-              agePrompt: 'Bem-vindo! Escolha uma faixa etária para começar.',
+              agePrompt: 'Passo 1: Escolha um grupo etário para começar.',
               ageOptions: {
-                '0-2': '0-2 meses',
-                '2-6': '2-6 meses',
-                '6-24': '6-24 meses',
-                '2y+': '2+ anos',
+                '0-2': { primary: '0 meses', secondary: '2 meses', align: 'start', accessible: '0 a 2 meses' },
+                '2-6': { primary: '2 meses', secondary: '6 meses', align: 'start', accessible: '2 a 6 meses' },
+                '6-11': { primary: '6 meses', secondary: '11 anos', align: 'start', accessible: '6 meses a 11 anos' },
+                '12+': { primary: '12 anos', secondary: 'ou mais', align: 'center', accessible: '12 anos ou mais' },
+                '2y+': { primary: '12 anos', secondary: 'ou mais', align: 'center', accessible: '12 anos ou mais' },
               },
               ageSelectLabel: 'Selecione a idade',
               infantCriticalMessage:
                 '<strong>Busque atendimento médico imediato.</strong> Se uma criança com menos de 60 dias tiver febre, é uma emergência médica. Entre em contato com o pediatra ou procure atendimento com um profissional de saúde imediatamente.',
-              weightLabel: 'Peso do paciente',
+              weightLabel: 'Passo 2: Inserir peso',
               weightInputLabel: 'Digite o peso',
               weightPlaceholder: 'Digite o peso',
               weightUnitAria: 'Selecionar unidade de peso',
               calculate: 'Calcular',
+              calculateStep: 'Passo 3: Calcular!',
             },
             units: {
               lbs: 'lbs',

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
     }
 
     .layout {
-      width: min(820px, 100%);
+      width: min(760px, 100%);
       margin: 0 auto;
       display: flex;
       flex-direction: column;
@@ -248,8 +248,8 @@
       box-shadow: var(--shadow-card);
       padding: clamp(24px, 4vw, 36px);
       width: 100%;
-      max-width: min(760px, 100%);
-      margin: 0;
+      max-width: min(720px, 100%);
+      margin: 0 auto;
     }
 
     .card.card--calculator,
@@ -260,6 +260,8 @@
 
     .calculator-widget-host {
       width: 100%;
+      max-width: 720px;
+      margin: 0 auto;
     }
 
     .donate-card {

--- a/style.css
+++ b/style.css
@@ -366,6 +366,26 @@ button:focus-visible {
     0 3px 12px rgba(12, 52, 82, 0.18);
 }
 
+@keyframes calculator-button-attention {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow:
+      0 20px 44px rgba(13, 52, 82, 0.24),
+      0 4px 14px rgba(12, 52, 82, 0.18);
+  }
+  50% {
+    transform: translateY(-6px) scale(1.03);
+    box-shadow:
+      0 32px 60px rgba(13, 52, 82, 0.3),
+      0 10px 22px rgba(12, 52, 82, 0.24);
+  }
+}
+
+#calculator button.button--attention {
+  animation: calculator-button-attention 1.25s ease-in-out 0s 2;
+}
+
 .translation-overlay[hidden] {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Format the widget age buttons into stacked labels with accessible fallbacks, center the 12+ option, and tighten the weight input/unit layout.
- Match the localized calculator strings to the new multi-line age labels and keep the cards centered across locales.
- Narrow the main layout width so the calculator, donate, and disclaimer cards align on the page.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22a5615d88329a11a29e07d126db4