### PR TITLE
Fix footer legal links

### DIFF
--- a/about.html
+++ b/about.html
@@ -771,21 +771,21 @@
       <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
       <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
 
       <details class="cd-legal cd-legal--accordion">
         <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
         <nav id="legal-links" aria-label="Legal and policy links">
-          <a href="/legal/terms">Terms of Use</a>
-          <a href="/legal/privacy">Privacy Policy</a>
-          <a href="/legal/disclaimer">Disclaimer</a>
-          <a href="/legal/aup">Acceptable Use</a>
-          <a href="/legal/dmca">DMCA Policy</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
         </nav>
       </details>
 

--- a/contact.html
+++ b/contact.html
@@ -766,21 +766,21 @@
     <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
     <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-      <a href="/legal/terms">Terms of Use</a>
-      <a href="/legal/privacy">Privacy Policy</a>
-      <a href="/legal/disclaimer">Disclaimer</a>
-      <a href="/legal/aup">Acceptable Use</a>
-      <a href="/legal/dmca">DMCA Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
     </nav>
 
     <details class="cd-legal cd-legal--accordion">
       <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
       <nav id="legal-links" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
     </details>
 

--- a/donations.html
+++ b/donations.html
@@ -649,21 +649,21 @@
     <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
     <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-      <a href="/legal/terms">Terms of Use</a>
-      <a href="/legal/privacy">Privacy Policy</a>
-      <a href="/legal/disclaimer">Disclaimer</a>
-      <a href="/legal/aup">Acceptable Use</a>
-      <a href="/legal/dmca">DMCA Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
     </nav>
 
     <details class="cd-legal cd-legal--accordion">
       <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
       <nav id="legal-links" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
     </details>
 

--- a/index-es.html
+++ b/index-es.html
@@ -1121,21 +1121,21 @@
     <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
     <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-      <a href="/legal/terms">Terms of Use</a>
-      <a href="/legal/privacy">Privacy Policy</a>
-      <a href="/legal/disclaimer">Disclaimer</a>
-      <a href="/legal/aup">Acceptable Use</a>
-      <a href="/legal/dmca">DMCA Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
     </nav>
 
     <details class="cd-legal cd-legal--accordion">
       <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
       <nav id="legal-links" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
     </details>
 

--- a/index-fr.html
+++ b/index-fr.html
@@ -1121,21 +1121,21 @@
     <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
     <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-      <a href="/legal/terms">Terms of Use</a>
-      <a href="/legal/privacy">Privacy Policy</a>
-      <a href="/legal/disclaimer">Disclaimer</a>
-      <a href="/legal/aup">Acceptable Use</a>
-      <a href="/legal/dmca">DMCA Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
     </nav>
 
     <details class="cd-legal cd-legal--accordion">
       <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
       <nav id="legal-links" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
     </details>
 

--- a/index-pt.html
+++ b/index-pt.html
@@ -1121,21 +1121,21 @@
     <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
     <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-      <a href="/legal/terms">Terms of Use</a>
-      <a href="/legal/privacy">Privacy Policy</a>
-      <a href="/legal/disclaimer">Disclaimer</a>
-      <a href="/legal/aup">Acceptable Use</a>
-      <a href="/legal/dmca">DMCA Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
     </nav>
 
     <details class="cd-legal cd-legal--accordion">
       <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
       <nav id="legal-links" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
     </details>
 

--- a/index.html
+++ b/index.html
@@ -1221,21 +1221,21 @@
     <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
     <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-      <a href="/legal/terms">Terms of Use</a>
-      <a href="/legal/privacy">Privacy Policy</a>
-      <a href="/legal/disclaimer">Disclaimer</a>
-      <a href="/legal/aup">Acceptable Use</a>
-      <a href="/legal/dmca">DMCA Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+      <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
     </nav>
 
     <details class="cd-legal cd-legal--accordion">
       <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
       <nav id="legal-links" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
     </details>
 

--- a/legal/disclaimer.html
+++ b/legal/disclaimer.html
@@ -14,5 +14,5 @@ body{font-family:'Nunito',sans-serif;margin:0;padding:0;background:#f8faf9;color
 <header class="header"><h1>Medical & Site Disclaimer</h1><p>Important safety information and limits of our tools</p><p><em>Effective October 03, 2025</em></p></header>
 <div class="container"><div class="card"><h2>General Information</h2><p>CloseDose is not a substitute for professional advice...</p></div></div>
 <footer class="footer">© 2025 CloseDose — Educational use only. Not medical advice.<br>
-<a href="/terms.html">Terms</a> | <a href="/privacy.html">Privacy</a> | <a href="/disclaimer.html">Disclaimer</a> | <a href="/dmca.html">DMCA</a> | <a href="/acceptable-use.html">Acceptable Use</a>
+<a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
 </footer></body></html>

--- a/legal/dmca.html
+++ b/legal/dmca.html
@@ -14,5 +14,5 @@ body{font-family:'Nunito',sans-serif;margin:0;padding:0;background:#f8faf9;color
 <header class="header"><h1>DMCA Policy</h1><p>Copyright complaint and counter-notice procedures</p><p><em>Effective October 03, 2025</em></p></header>
 <div class="container"><div class="card"><h2>Overview</h2><p>CloseDose respects the intellectual property rights of others...</p></div></div>
 <footer class="footer">© 2025 CloseDose — Educational use only. Not medical advice.<br>
-<a href="/terms.html">Terms</a> | <a href="/privacy.html">Privacy</a> | <a href="/disclaimer.html">Disclaimer</a> | <a href="/dmca.html">DMCA</a> | <a href="/acceptable-use.html">Acceptable Use</a>
+<a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
 </footer></body></html>

--- a/legal/linking.html
+++ b/legal/linking.html
@@ -14,5 +14,5 @@ body{font-family:'Nunito',sans-serif;margin:0;padding:0;background:#f8faf9;color
 <header class="header"><h1>Acceptable Use & Linking Policy</h1><p>How you may use CloseDose Services and link to our site</p><p><em>Effective October 03, 2025</em></p></header>
 <div class="container"><div class="card"><h2>Acceptable Use</h2><p>Do not misuse the Services...</p></div></div>
 <footer class="footer">© 2025 CloseDose — Educational use only. Not medical advice.<br>
-<a href="/terms.html">Terms</a> | <a href="/privacy.html">Privacy</a> | <a href="/disclaimer.html">Disclaimer</a> | <a href="/dmca.html">DMCA</a> | <a href="/acceptable-use.html">Acceptable Use</a>
+<a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
 </footer></body></html>

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -14,5 +14,5 @@ body{font-family:'Nunito',sans-serif;margin:0;padding:0;background:#f8faf9;color
 <header class="header"><h1>Privacy Policy</h1><p>How we collect, use, and protect information</p><p><em>Effective October 03, 2025</em></p></header>
 <div class="container"><div class="card"><h2>Scope</h2><p>This Privacy Policy explains how CloseDose handles information...</p></div></div>
 <footer class="footer">© 2025 CloseDose — Educational use only. Not medical advice.<br>
-<a href="/terms.html">Terms</a> | <a href="/privacy.html">Privacy</a> | <a href="/disclaimer.html">Disclaimer</a> | <a href="/dmca.html">DMCA</a> | <a href="/acceptable-use.html">Acceptable Use</a>
+<a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
 </footer></body></html>

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -14,5 +14,5 @@ body{font-family:'Nunito',sans-serif;margin:0;padding:0;background:#f8faf9;color
 <header class="header"><h1>Terms of Use</h1><p>Rules for using CloseDose services and content</p><p><em>Effective October 03, 2025</em></p></header>
 <div class="container"><div class="card"><h2>Overview</h2><p>By using CloseDose, you agree to these terms...</p></div></div>
 <footer class="footer">© 2025 CloseDose — Educational use only. Not medical advice.<br>
-<a href="/terms.html">Terms</a> | <a href="/privacy.html">Privacy</a> | <a href="/disclaimer.html">Disclaimer</a> | <a href="/dmca.html">DMCA</a> | <a href="/acceptable-use.html">Acceptable Use</a>
+<a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA</a> | <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
 </footer></body></html>

--- a/medication-guides.html
+++ b/medication-guides.html
@@ -950,21 +950,21 @@
       <p class="cd-copy">© 2025 CloseDose. All rights reserved.</p>
 
       <nav class="cd-legal cd-legal--full" aria-label="Legal and policy links">
-        <a href="/legal/terms">Terms of Use</a>
-        <a href="/legal/privacy">Privacy Policy</a>
-        <a href="/legal/disclaimer">Disclaimer</a>
-        <a href="/legal/aup">Acceptable Use</a>
-        <a href="/legal/dmca">DMCA Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+        <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
       </nav>
 
       <details class="cd-legal cd-legal--accordion">
         <summary aria-controls="legal-links">Legal &amp; Policies ▾</summary>
         <nav id="legal-links" aria-label="Legal and policy links">
-          <a href="/legal/terms">Terms of Use</a>
-          <a href="/legal/privacy">Privacy Policy</a>
-          <a href="/legal/disclaimer">Disclaimer</a>
-          <a href="/legal/aup">Acceptable Use</a>
-          <a href="/legal/dmca">DMCA Policy</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/terms">Terms of Use</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/privacy">Privacy Policy</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/disclaimer">Disclaimer</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/aup">Acceptable Use</a>
+          <a href="https://nsm0101.github.io/CloseDoseAlt/legal/dmca">DMCA Policy</a>
         </nav>
       </details>
 


### PR DESCRIPTION
## Summary
- update footer legal links across site pages to point to the GitHub Pages URLs
- align legal document footers with the same external legal URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29420c9508329a3ce1e78a6d30366