### PR TITLE
Add privacy policy page

### DIFF
--- a/policy.html
+++ b/policy.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Privacy Policy • CloseDose</title>
+  <style>
+    :root{--teal:#24A687;--ink:#0B1F1A;--muted:#4A5A55;--bg:#fff;--border:#E8F2EF;--maxw:840px}
+    body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial;color:var(--ink);background:var(--bg);line-height:1.6}
+    header{padding:48px 20px 16px;text-align:center;border-bottom:1px solid var(--border);background:radial-gradient(1200px 200px at 50% -80px, rgba(36,166,135,0.08), transparent 70%)}
+    .brand{font-weight:800;letter-spacing:.2px;color:var(--teal);text-transform:uppercase;font-size:14px;margin-bottom:6px;display:inline-block}
+    h1{margin:6px 0 4px;font-size:clamp(26px,4vw,34px);line-height:1.15}
+    .meta{color:var(--muted);font-size:14px;margin-top:4px}
+    main{padding:28px 20px 120px;max-width:var(--maxw);margin:0 auto}
+    h2{font-size:clamp(18px,2.5vw,22px);margin:22px 0 8px}
+    ul{padding-left:20px} li{margin:6px 0}
+    .card{background:#fff;border:1px solid var(--border);border-radius:14px;padding:20px}
+    footer{border-top:1px solid var(--border)} .footer-inner{max-width:var(--maxw);margin:0 auto;padding:18px 20px 26px;display:flex;gap:12px;flex-wrap:wrap;justify-content:center;font-size:14px}
+    .footer-inner a{color:#4A5A55;text-decoration:none;border-bottom:1px dashed rgba(0,0,0,.15)} .footer-inner a:hover{color:#0B1F1A}
+    .watermark{pointer-events:none;position:fixed;right:-30px;bottom:-10px;z-index:1;opacity:.06;font-weight:900;font-size:120px;line-height:1;color:var(--teal);transform:rotate(-12deg);letter-spacing:1.5px;user-select:none}
+    @media (prefers-color-scheme: dark){
+      body{background:#0c1211;color:#ebf4f1}
+      .card{background:#0f1716;border-color:#122320}
+      .footer-inner{background:#0f1716}
+      .footer-inner a{color:#9fb9b2}
+      .meta{color:#9fb9b2}
+    }
+  </style>
+</head>
+<body>
+<div class="watermark">CloseDose</div>
+<header>
+  <div class="brand">CloseDose</div>
+  <h1>Privacy Policy</h1>
+  <div class="meta">Effective Date: <strong>October 02, 2025</strong></div>
+</header>
+
+<main>
+  <section class="card">
+    <p><strong>Scope.</strong> This Privacy Policy explains how CloseDose LLC collects, uses, and shares information when you use CloseDose.com and related services.</p>
+
+    <h2>What We Collect</h2>
+    <p>We aim to avoid collecting personal data. We do not request names, birth dates, or health records. We may collect limited device and usage data (IP address, browser type, pages viewed, referring URLs, timestamps) via first-party analytics or privacy-respecting tools. If you contact us, we will receive the information you provide (e.g., email address, message content).</p>
+
+    <h2>Cookies</h2>
+    <p>We may use strictly necessary cookies to maintain session preferences and optional analytics cookies to understand feature usage. You can control cookies through your browser settings.</p>
+
+    <h2>Use of Information</h2>
+    <p>We use information to operate, maintain, and improve the Services; detect, prevent, and address technical issues; and respond to inquiries.</p>
+
+    <h2>Sharing</h2>
+    <p>We do not sell personal information. We may share limited data with service providers who help us operate the Services (e.g., hosting, analytics) under confidentiality obligations, or when required by law.</p>
+
+    <h2>PHI</h2>
+    <p>We do not request or store Protected Health Information (PHI). Do not enter identifiable health information into free-text forms.</p>
+
+    <h2>Data Security &amp; Retention</h2>
+    <p>We use reasonable administrative, technical, and physical safeguards. No method of transmission or storage is 100% secure. We retain data only as long as necessary for the purposes described.</p>
+
+    <h2>Children’s Privacy</h2>
+    <p>The Services are not directed to children under 13. Parents/caregivers may use the dosing calculators for their dependents.</p>
+
+    <h2>Your Choices</h2>
+    <p>You may disable cookies, use browser privacy controls, or contact us to request deletion of messages you've sent to us.</p>
+
+    <h2>International Users</h2>
+    <p>If you access the Services from outside the U.S., you consent to processing in the U.S. and to U.S. law.</p>
+
+    <h2>Changes</h2>
+    <p>We may update this Policy and will post the new Effective Date when changes occur.</p>
+
+    <h2>Contact</h2>
+    <p>CloseDose LLC, [Mailing Address]. Email: <a href="mailto:privacy@closedose.com">privacy@closedose.com</a>.</p>
+  </section>
+</main>
+
+<footer>
+  <div class="footer-inner">
+    <a href="terms.html">Terms</a> •
+    <a href="privacy.html">Privacy</a> •
+    <a href="disclaimer.html">Disclaimer</a> •
+    <a href="dmca.html">DMCA</a> •
+    <a href="linking.html">Acceptable Use &amp; Linking</a>
+  </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated policy.html page describing CloseDose privacy practices
- include responsive styling, watermark, and footer navigation links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a34db97c8329b40a7a2201fbb20e